### PR TITLE
Fix bug which rendered Session.popdata() unusable

### DIFF
--- a/pykarbon/terminal.py
+++ b/pykarbon/terminal.py
@@ -532,7 +532,7 @@ class Session():
             String of the data read from the port. Returns empty string if the queue is empty
         '''
         try:
-            out = self.data.get_nowait(0)
+            out = self.data.get_nowait()
             self.prev_line = out
         except queue.Empty:
             out = ""


### PR DESCRIPTION
When calling popdata() on any Session object, the method would immediately crash with `TypeError: get_nowait() takes 1 positional argument but 2 were given`.

Since `popdata()` is used in the only example program in [this official tutorial][1], I think the fix is of particular importance.

The bug fixed here was introduced in [26fb459f][2] were the type of attribute `self.data` was changed from a standard `list` to `queue.Queue` and the list operation `data.pop(0)` (_remove first element_) was incorrectly translated to the Queue operation `data.pop_nowait(0)` which does not support any parameters, as it can only remove the first element.

[1]: https://support.onlogic.com/documentation/dio-digital-input-output-faq/
[2]: https://github.com/onlogic/Pykarbon/commit/26fb459f5f8529dc14ae9731e03ad6804a1c0aa7#diff-880e8a0e1137d7e2c79e7b9aaadceb0bee90853b98c889c1a6bf474a2473f628L539-R538